### PR TITLE
add shutdown() to Database and QueryEvaluator to shut down connection pools

### DIFF
--- a/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/ApachePoolingDatabase.scala
@@ -90,6 +90,8 @@ class ApachePoolingDatabase(
     }
   }
 
+  def shutdown() { connectionPool.close() }
+
   def open() = poolingDataSource.getConnection()
 
   override def toString = dbhosts.head + "_" + dbname

--- a/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/AutoDisablingDatabase.scala
@@ -33,4 +33,6 @@ class AutoDisablingDatabase(database: Database, dbhost: String, protected val di
   }
 
   def close(connection: Connection) { database.close(connection) }
+
+  def shutdown() { database.shutdown() }
 }

--- a/src/main/scala/com/twitter/querulous/database/Database.scala
+++ b/src/main/scala/com/twitter/querulous/database/Database.scala
@@ -29,6 +29,8 @@ trait Database {
 
   def close(connection: Connection)
 
+  def shutdown()
+
   def withConnection[A](f: Connection => A): A = {
     val connection = open()
     try {

--- a/src/main/scala/com/twitter/querulous/database/SingleConnectionDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/SingleConnectionDatabase.scala
@@ -32,6 +32,8 @@ class SingleConnectionDatabase(dbhosts: List[String], dbname: String, username: 
     }
   }
 
+  def shutdown() { }
+
   def open() = connectionFactory.createConnection()
   override def toString = dbhosts.head + "_" + dbname
 }

--- a/src/main/scala/com/twitter/querulous/database/StatsCollectingDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/StatsCollectingDatabase.scala
@@ -38,4 +38,6 @@ class StatsCollectingDatabase(database: Database, stats: StatsCollector)
       }
     }
   }
+
+  def shutdown() { database.shutdown() }
 }

--- a/src/main/scala/com/twitter/querulous/database/TimingOutDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/database/TimingOutDatabase.scala
@@ -49,4 +49,6 @@ class TimingOutDatabase(database: Database, dbhosts: List[String], dbname: Strin
   override def open() = getConnection(openTimeout)
 
   def close(connection: Connection) { database.close(connection) }
+
+  def shutdown() { database.shutdown() }
 }

--- a/src/main/scala/com/twitter/querulous/evaluator/AutoDisablingQueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/AutoDisablingQueryEvaluator.scala
@@ -51,4 +51,5 @@ class AutoDisablingQueryEvaluator (
     }
   }
 
+  def shutdown() { queryEvaluator.shutdown() }
 }

--- a/src/main/scala/com/twitter/querulous/evaluator/QueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/QueryEvaluator.scala
@@ -110,4 +110,6 @@ trait QueryEvaluator {
     insert(QueryClass.Execute, query, params: _*)
 
   def transaction[T](f: Transaction => T): T
+
+  def shutdown()
 }

--- a/src/main/scala/com/twitter/querulous/evaluator/StandardQueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/StandardQueryEvaluator.scala
@@ -76,4 +76,6 @@ class StandardQueryEvaluator(protected val database: Database, queryFactory: Que
   }
 
   override def hashCode = database.hashCode
+
+  def shutdown() { database.shutdown() }
 }

--- a/src/main/scala/com/twitter/querulous/evaluator/Transaction.scala
+++ b/src/main/scala/com/twitter/querulous/evaluator/Transaction.scala
@@ -57,4 +57,6 @@ class Transaction(queryFactory: QueryFactory, connection: Connection) extends Qu
   }
 
   def transaction[T](f: Transaction => T) = f(this)
+
+  def shutdown() { }
 }

--- a/src/main/scala/com/twitter/querulous/test/FakeDatabase.scala
+++ b/src/main/scala/com/twitter/querulous/test/FakeDatabase.scala
@@ -17,4 +17,6 @@ class FakeDatabase(connection: Connection, before: Option[String => Unit]) exten
   def close(connection: Connection) {
     before.foreach { _("close") }
   }
+
+  def shutdown() { }
 }

--- a/src/main/scala/com/twitter/querulous/test/FakeQueryEvaluator.scala
+++ b/src/main/scala/com/twitter/querulous/test/FakeQueryEvaluator.scala
@@ -15,4 +15,5 @@ class FakeQueryEvaluator[A](trans: Transaction, resultSets: Seq[ResultSet]) exte
   def nextId(tableName: String) = 0
   def insert(queryClass: QueryClass, query: String, params: Any*) = 0
   def transaction[T](f: Transaction => T) = f(trans)
+  def shutdown() { }
 }

--- a/src/test/scala/com/twitter/querulous/unit/DatabaseSpec.scala
+++ b/src/test/scala/com/twitter/querulous/unit/DatabaseSpec.scala
@@ -87,6 +87,7 @@ class DatabaseSpec extends Specification with JMocker with ClassMocker {
     val fake = new Object with Database {
       def open() = null
       def close(connection: Connection) = ()
+      def shutdown() { }
     }.asInstanceOf[{def url(a: List[String], b:String, c:Map[String, String]): String}]
 
     "add default unicode urlOptions" in {

--- a/src/test/scala/com/twitter/querulous/unit/TimingOutDatabaseSpec.scala
+++ b/src/test/scala/com/twitter/querulous/unit/TimingOutDatabaseSpec.scala
@@ -24,6 +24,7 @@ class TimingOutDatabaseSpec extends Specification with JMocker with ClassMocker 
         connection
       }
       def close(connection: Connection) = ()
+      def shutdown() { }
     }
 
     expect {


### PR DESCRIPTION
Connection pools are hidden in Database/QueryEvaluator, so it isn't possible to release connections in a pool. This change adds a shutdown() method on those traits, and implements it in ApachePoolingDatabase that closes the pool.

This is useful to me so I can run test code in sbt without running out of connections. But I can imagine it might be useful in other situations.
