### PR TITLE
fail fast when the connection pool is under-populated, corresponding conf

### DIFF
--- a/querulous-core/src/test/scala/com/twitter/querulous/integration/ThrottledPoolingDatabaseWithFakeConnSpec.scala
+++ b/querulous-core/src/test/scala/com/twitter/querulous/integration/ThrottledPoolingDatabaseWithFakeConnSpec.scala
@@ -1,13 +1,26 @@
 package com.twitter.querulous.integration
 
-import com.twitter.util.Time
 import com.twitter.conversions.time._
-import com.twitter.querulous.evaluator.StandardQueryEvaluatorFactory
+import com.twitter.querulous.evaluator.{QueryEvaluator, StandardQueryEvaluatorFactory}
 import com.twitter.querulous.ConfiguredSpecification
 import com.twitter.querulous.sql.{FakeContext, FakeDriver}
 import com.mysql.jdbc.exceptions.jdbc4.CommunicationsException
-import com.twitter.querulous.database.{PoolEmptyException, Database, ThrottledPoolingDatabaseFactory}
 import com.twitter.querulous.query.{SqlQueryTimeoutException, TimingOutQueryFactory, SqlQueryFactory}
+import collection.immutable.Vector
+import util.Random
+import com.twitter.util.{Duration, Time}
+import com.twitter.querulous.database.{PoolFailFastException, PoolEmptyException, Database, ThrottledPoolingDatabaseFactory}
+import com.twitter.querulous.config.FailFastPolicyConfig
+
+class MockRandom extends Random {
+  private[this] var currIndex = 0
+  private[this] val vals: IndexedSeq[Double] = Vector(0.75, 0.85, 0.25, 0.25, 0.25)
+  // cycle through the list of values specified above
+  override def nextDouble(): Double = {
+    currIndex += 1
+    vals((currIndex - 1)%vals.size)
+  }
+}
 
 object ThrottledPoolingDatabaseWithFakeConnSpec {
   // configure repopulation interval to a minute to avoid conn repopulation when test running
@@ -22,25 +35,58 @@ object ThrottledPoolingDatabaseWithFakeConnSpec {
     1.second, 100.milliseconds, Map("connectTimeout" -> "2000"))
   val testRepopulatedLongConnTimeoutEvaluatorFactory = new StandardQueryEvaluatorFactory(
     testRepopulatedLongConnTimeoutDbFactory, testQueryFactory)
+
+  val failFastPolicyConfig = new FailFastPolicyConfig {
+    def highWaterMark: Double = 0.75
+    def openTimeout: Duration = 1.second
+    def lowWaterMark: Double = 0.5
+    def rng: Option[Random] = Some(new MockRandom())
+  }
+  val testFailFastDatabaseFactory = new ThrottledPoolingDatabaseFactory(Some("test"), 8, 1.second,
+    60.second, 60.seconds, Map.empty, Some(failFastPolicyConfig))
+  val testFailFastEvaluatorFactory = new StandardQueryEvaluatorFactory(testFailFastDatabaseFactory,
+    testQueryFactory)
+
+  val testDatabaseFactoryWithDefaultFailFastPolicy = new ThrottledPoolingDatabaseFactory(
+    Some("test"), 8, 1.second, 60.second, 60.seconds, Map.empty, None)
+  val testEvaluatorFactoryWithDefaultFailFastPolicy = new StandardQueryEvaluatorFactory(
+    testDatabaseFactoryWithDefaultFailFastPolicy, testQueryFactory)
+
+  def destroyConnection(queryEvaluator: QueryEvaluator, host: String, numConns: Int = 1) {
+    FakeContext.markServerDown(host)
+    try {
+      for(i <- 0 until numConns) {
+        try {
+          queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) }
+          assert(false)
+        } catch {
+          case e: CommunicationsException => // expected
+          case t: Throwable => throw t
+        }
+      }
+    } finally {
+      FakeContext.markServerUp(host)
+    }
+  }
 }
 
 class ThrottledPoolingDatabaseWithFakeConnSpec extends ConfiguredSpecification {
   import ThrottledPoolingDatabaseWithFakeConnSpec._
 
+  val host = config.hostnames.mkString(",") + "/" + config.database
+  FakeContext.setQueryResult(host, "SELECT 1 FROM DUAL", Array(Array[java.lang.Object](1.asInstanceOf[AnyRef])))
+  FakeContext.setQueryResult(host, "SELECT 2 FROM DUAL", Array(Array[java.lang.Object](2.asInstanceOf[AnyRef])))
+
   doBeforeSpec { Database.driverName = FakeDriver.DRIVER_NAME }
 
   "ThrottledJdbcPoolSpec" should {
-    val host = config.hostnames.mkString(",") + "/" + config.database
     val queryEvaluator = testEvaluatorFactory(config)
-
-    FakeContext.setQueryResult(host, "SELECT 1 FROM DUAL", Array(Array[java.lang.Object](1.asInstanceOf[AnyRef])))
-    FakeContext.setQueryResult(host, "SELECT 2 FROM DUAL", Array(Array[java.lang.Object](2.asInstanceOf[AnyRef])))
-    "execute some queries" >> {
+    "execute some queries" in {
       queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
       queryEvaluator.select("SELECT 2 FROM DUAL") { r => r.getInt(1) } mustEqual List(2)
     }
 
-    "failfast after a host is down" >> {
+    "failfast after a host is down" in {
       queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
       FakeContext.markServerDown(host)
       try {
@@ -53,7 +99,7 @@ class ThrottledPoolingDatabaseWithFakeConnSpec extends ConfiguredSpecification {
       }
     }
 
-    "failfast after connections are closed due to query timeout" >> {
+    "failfast after connections are closed due to query timeout" in {
       queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
       FakeContext.setTimeTakenToExecQuery(host, 1.second)
       try {
@@ -67,7 +113,7 @@ class ThrottledPoolingDatabaseWithFakeConnSpec extends ConfiguredSpecification {
       }
     }
 
-    "repopulate the pool every repopulation interval" >> {
+    "repopulate the pool every repopulation interval" in {
       val queryEvaluator = testRepopulatedEvaluatorFactory(config)
 
       queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
@@ -84,7 +130,7 @@ class ThrottledPoolingDatabaseWithFakeConnSpec extends ConfiguredSpecification {
       }
     }
 
-    "repopulate the pool even if it takes longer to establish a connection than repopulation interval" >> {
+    "repopulate the pool even if it takes longer to establish a connection than repopulation interval" in {
       val queryEvaluator = testRepopulatedLongConnTimeoutEvaluatorFactory(config)
 
       queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
@@ -101,6 +147,75 @@ class ThrottledPoolingDatabaseWithFakeConnSpec extends ConfiguredSpecification {
         FakeContext.setTimeTakenToOpenConn(host, 0.second)
         FakeContext.markServerUp(host)
       }
+    }
+  }
+
+  "ThrottledJdbcPoolWithFailFastPolicy" should {
+    val queryEvaluator = testFailFastEvaluatorFactory(config)
+
+    "execute query normally as the pool is full or above highWaterMark" in {
+      // number of connections in the pool 8
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // number of connections in the pool 7
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+    }
+
+    // here we should see more aggressive timeout applied on acquiring connection, but currently
+    // it is hard to test that. Nonetheless, this is covered by the unit test.
+    "execute query normally until the pool reaches the lowWaterMark" in {
+      destroyConnection(queryEvaluator, host, 2)
+      // number of connections in the pool 6 = 8 * 0.75, at highWaterMark
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // number of connection is 4 = 8 * 0.5, at lowWaterMark
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+    }
+
+    "fail fast when the pool is under the lowWaterMark and throw PoolEmptyException when the pool is empty" in {
+      destroyConnection(queryEvaluator, host, 5)
+      // number of connection is at 3, but still fine because the first double out of random number
+      // generator is 0.75, 3 = 8 * 0.5 * 0.75
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      // 3 < 8 * 0.5 * 0.5
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } must throwA[PoolFailFastException]
+      destroyConnection(queryEvaluator, host, 3)
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } must throwA[PoolEmptyException]
+    }
+  }
+
+  "ThrottledJdbcPoolWithDefaultFailFastPolicy" should {
+    "execute query normally as the pool until there is no connection in the pool" in {
+      val queryEvaluator = testEvaluatorFactoryWithDefaultFailFastPolicy(config)
+
+      // number of connections in the pool 8
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // number of connections in the pool 7
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // number of connections in the pool 6
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // number of connections in the pool 5
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // number of connections in the pool 4
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // number of connections in the pool 3
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // number of connections in the pool 2
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // number of connections in the pool 1
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } mustEqual List(1)
+      destroyConnection(queryEvaluator, host)
+      // no connection left in the pool
+      queryEvaluator.select("SELECT 1 FROM DUAL") { r => r.getInt(1) } must throwA[PoolEmptyException]
     }
   }
 

--- a/querulous-core/src/test/scala/com/twitter/querulous/unit/DefaultFailFastPolicySpec.scala
+++ b/querulous-core/src/test/scala/com/twitter/querulous/unit/DefaultFailFastPolicySpec.scala
@@ -1,0 +1,33 @@
+package com.twitter.querulous.unit
+
+import com.twitter.conversions.time._
+import org.specs.Specification
+import org.specs.mock.{ClassMocker, JMocker}
+import java.sql.Connection
+import com.twitter.querulous.database.{FailFastBasedOnNumConnsPolicy, PoolEmptyException, ThrottledPool}
+
+class DefaultFailFastPolicySpec extends Specification with JMocker with ClassMocker {
+  val conn = mock[Connection]
+  val connFactory = mock[TestConnectionFactory]
+  val ffp = FailFastBasedOnNumConnsPolicy(0, 0, 1.second, None)
+  val pool = mock[ThrottledPool]
+
+  "DefaultFailFastPolicySpec" should {
+    "throw PoolEmptyException when the pool does not have any connection" in {
+      expect {
+        one(pool).getTotal() willReturn 0
+      }
+      ffp.failFast(pool)(connFactory.getConnection(_)) must throwA[PoolEmptyException]
+    }
+
+    "get a connection with the normal timeout setting even if the pool only has one connection" in {
+      expect {
+        one(pool).getTotal() willReturn 1
+        2.of(pool).size willReturn 8
+        one(pool).timeout willReturn 2.seconds
+        one(connFactory).getConnection(2.seconds) willReturn conn
+      }
+      ffp.failFast(pool)(connFactory.getConnection(_)) mustEqual conn
+    }
+  }
+}

--- a/querulous-core/src/test/scala/com/twitter/querulous/unit/FailFastBasedOnNumConnsPolicySpec.scala
+++ b/querulous-core/src/test/scala/com/twitter/querulous/unit/FailFastBasedOnNumConnsPolicySpec.scala
@@ -1,0 +1,101 @@
+package com.twitter.querulous.unit
+
+import com.twitter.conversions.time._
+import org.specs.Specification
+import org.specs.mock.{ClassMocker, JMocker}
+import com.twitter.util.Duration
+import java.sql.Connection
+import java.security.InvalidParameterException
+import com.twitter.querulous.database.{FailFastBasedOnNumConnsPolicy, PoolFailFastException, PoolEmptyException, ThrottledPool}
+
+trait TestConnectionFactory {
+  def getConnection(timeout: Duration): Connection
+}
+
+class FailFastBasedOnNumConnsPolicySpec extends Specification with JMocker with ClassMocker {
+  val conn = mock[Connection]
+  val rng = mock[scala.util.Random]
+  val connFactory = mock[TestConnectionFactory]
+  val ffp = FailFastBasedOnNumConnsPolicy(0.75, 0.5, 1.second, Some(rng))
+  val pool = mock[ThrottledPool]
+
+  "FailFastBasedOnNumConnsPolicySpec" should {
+    "throw InvalidParameterException when highWaterMark is lower than lowWaterMark" in {
+      FailFastBasedOnNumConnsPolicy(0.5, 0.75, 1.second, Some(rng)) must throwA[InvalidParameterException]
+    }
+
+    "throw InvalidParameterException when lowWaterMark is negative or 0" in {
+      FailFastBasedOnNumConnsPolicy(0.5, -0.1, 1.second, Some(rng)) must throwA[InvalidParameterException]
+    }
+
+    "throw InvalidParameterException when hightWaterMark is greater than 1" in {
+      FailFastBasedOnNumConnsPolicy(1.1, 0.75, 1.second, Some(rng)) must throwA[InvalidParameterException]
+    }
+
+    "throw PoolEmptyException when the pool does not have any connection" in {
+      expect {
+        one(pool).getTotal() willReturn 0
+      }
+      ffp.failFast(pool)(connFactory.getConnection(_)) must throwA[PoolEmptyException]
+    }
+
+    "throw PoolFailFastException when pool below lowWaterMark and unlucky" in {
+      expect {
+        one(pool).getTotal() willReturn 2
+        one(pool).size willReturn 8
+        one(rng).nextDouble() willReturn 0.75
+        one(pool).size willReturn 8
+      }
+      ffp.failFast(pool)(connFactory.getConnection(_)) must throwA[PoolFailFastException]
+    }
+
+    "get a connection with the more aggressive timeout setting when pool below lowWaterMark and but lucky enough" in {
+      expect {
+        one(pool).getTotal() willReturn 2
+        one(pool).size willReturn 8
+        one(rng).nextDouble() willReturn 0.25
+        one(pool).size willReturn 8
+        one(connFactory).getConnection(1.second) willReturn conn
+      }
+      ffp.failFast(pool)(connFactory.getConnection(_)) mustEqual conn
+    }
+
+    "get a connection with the more aggressive timeout setting when pool below highWaterMark but at lowWaterMark" in {
+      expect {
+        one(pool).getTotal() willReturn 4
+        2.of(pool).size willReturn 8
+        one(connFactory).getConnection(1.second) willReturn conn
+      }
+      ffp.failFast(pool)(connFactory.getConnection(_)) mustEqual conn
+    }
+
+    "get a connection with the more aggressive timeout setting when pool below highWaterMark but above lowWaterMark" in {
+      expect {
+        one(pool).getTotal() willReturn 5
+        2.of(pool).size willReturn 8
+        one(connFactory).getConnection(1.second) willReturn conn
+      }
+      ffp.failFast(pool)(connFactory.getConnection(_)) mustEqual conn
+    }
+
+    "get a connection with the normal timeout setting when pool at highWaterMark" in {
+      expect {
+        one(pool).getTotal() willReturn 6
+        2.of(pool).size willReturn 8
+        one(pool).timeout willReturn 2.seconds
+        one(connFactory).getConnection(2.seconds) willReturn conn
+      }
+      ffp.failFast(pool)(connFactory.getConnection(_)) mustEqual conn
+    }
+
+    "get a connection with the normal timeout setting when pool above highWaterMark" in {
+      expect {
+        one(pool).getTotal() willReturn 7
+        2.of(pool).size willReturn 8
+        one(pool).timeout willReturn 2.seconds
+        one(connFactory).getConnection(2.seconds) willReturn conn
+      }
+      ffp.failFast(pool)(connFactory.getConnection(_)) mustEqual conn
+    }
+  }
+}


### PR DESCRIPTION
fail fast when the connection pool is under-populated, corresponding config, unit and integration tests
