### PR TITLE
Bug fix in MemoizingDatabase - use all host names as the hash key

### DIFF
--- a/querulous-core/src/main/scala/com/twitter/querulous/database/MemoizingDatabase.scala
+++ b/querulous-core/src/main/scala/com/twitter/querulous/database/MemoizingDatabase.scala
@@ -7,7 +7,7 @@ class MemoizingDatabaseFactory(val databaseFactory: DatabaseFactory) extends Dat
 
   def apply(dbhosts: List[String], dbname: String, username: String, password: String, urlOptions: Map[String, String], driverName: String) = synchronized {
     databases.getOrElseUpdate(
-      dbhosts.head + "/" + dbname,
+      dbhosts.toString + "/" + dbname,
       databaseFactory(dbhosts, dbname, username, password, urlOptions, driverName))
   }
 


### PR DESCRIPTION
Multiple QueryEvaluator could use the same host with different slaves. For example

evaluator 1 [ DB1, DB2]
evaluator 2 [ DB1, DB3]

They are different evaluators. MemoizingDatabase only used the first host to do the hashmap. Exception happens when the primary DB down.
