### PR TITLE
update to latest finagle, remove explict promise creation

### DIFF
--- a/project/build/QuerulousProject.scala
+++ b/project/build/QuerulousProject.scala
@@ -28,8 +28,8 @@ with SubversionPublisher {
     with DefaultRepos
     with SubversionPublisher
 
-  val utilVersion    = "1.11.8"
-  val finagleVersion = "1.9.2"
+  val utilVersion    = "1.12.3"
+  val finagleVersion = "1.9.6"
 
   class CoreProject(info: ProjectInfo) extends StandardLibraryProject(info) with Defaults {
     val utilCore  = "com.twitter"  % "util-core"            % utilVersion


### PR DESCRIPTION
remove explicit creation of Promises in BlockingDatabaseWrapper, and use the Future "within" method for timing out. The chained result should propagate cancellation properly in both directions. 

also upgrade to latest finagle/util. 
