### PR TITLE
Mix-in to provide customization of the properties of ResultSets generated by SqlQuery

### DIFF
--- a/querulous-core/src/main/scala/com/twitter/querulous/query/Query.scala
+++ b/querulous-core/src/main/scala/com/twitter/querulous/query/Query.scala
@@ -3,12 +3,18 @@ package com.twitter.querulous.query
 import java.sql.{ResultSet, Connection}
 import scala.collection.immutable.Map
 
+trait ResultSetGenerator {
+  def scrolling: Int
+  def direction: Int
+  def concurrency: Int
+}
+
 trait QueryFactory {
   def apply(connection: Connection, queryClass: QueryClass, queryString: String, params: Any*): Query
   def shutdown() = {}
 }
 
-trait Query {
+trait Query extends ResultSetGenerator {
   def select[A](f: ResultSet => A): Seq[A]
   def execute(): Int
   def addParams(params: Any*)
@@ -21,4 +27,12 @@ trait Query {
   private var ann = Map[String, String]()
   def addAnnotation(key: String, value:String) = ann = ann + (key -> value)
   def annotations: Map[String, String] = ann
+
+  override def scrolling: Int = ResultSet.TYPE_FORWARD_ONLY
+  override def direction: Int = ResultSet.FETCH_FORWARD
+  override def concurrency: Int = ResultSet.CONCUR_READ_ONLY
+}
+
+trait ScrollingResultSetGenerator extends ResultSetGenerator {
+  override def scrolling: Int = ResultSet.TYPE_SCROLL_INSENSITIVE
 }


### PR DESCRIPTION
I've run into a case where I would really like to be able to scroll backwards in the ResultSet produced by Query.select(). (Each domain object being populated from the select results needs information from several adjacent rows in the ResultSet, and the only way to determine when an object is fully populated is to scroll completely through all its rows into the next object's set of rows. Then, to keep from consuming a row it shouldn't, this process needs to scroll backwards a row.)

ResultSet properties are determined at Statement creation, but Statement creation is in a private method in SqlQuery. This is addressed in this patch by making an explicit trait for ResultSet generation, with a simple mixin for substituting values other than the de facto defaults.
