### PR TITLE
Fix a call by name that causes tons of QueryFactory objects to be created

### DIFF
--- a/querulous-core/src/main/scala/com/twitter/querulous/async/StandardAsyncQueryEvaluator.scala
+++ b/querulous-core/src/main/scala/com/twitter/querulous/async/StandardAsyncQueryEvaluator.scala
@@ -8,7 +8,7 @@ import com.twitter.querulous.evaluator.{Transaction, ParamsApplier}
 
 class StandardAsyncQueryEvaluatorFactory(
   databaseFactory: AsyncDatabaseFactory,
-  queryFactory: => QueryFactory)
+  queryFactory: QueryFactory)
 extends AsyncQueryEvaluatorFactory {
     def apply(
     hosts: List[String],
@@ -78,7 +78,9 @@ extends AsyncQueryEvaluator {
   }
 
   def shutdown() {
-    queryFactory.shutdown()
+    // TODO: Having to call shutdown on a factory object seems bizarre. We need to rewrite this
+    // (seems to be meant for tracing support) in a saner way.
+    // queryFactory.shutdown()
     database.shutdown()
   }
 


### PR DESCRIPTION
Seems like this was done as part of adding support for tracing, basically to provide a way to add "shutdown" functionality to QueryFactory. This doesn't seem like a good approach though, and I have added a TODO to revisit that (tracing is not currently in use).
