### PR TITLE
Implement per-thread connection caching in async querulous

### DIFF
--- a/querulous-core/src/main/scala/com/twitter/querulous/async/BlockingDatabaseWrapper.scala
+++ b/querulous-core/src/main/scala/com/twitter/querulous/async/BlockingDatabaseWrapper.scala
@@ -88,6 +88,8 @@ extends AsyncDatabase {
             // exception like a SQL constraint violation), it still doesn't hurt much to return/re-borrow
             // the connection from the underlying database, given that this should be rare.
             // TODO: Handle possible connection leakage if this thread is destroyed in some other way.
+            // (Note that leaking an exception from here will not kill the thread since the FuturePool
+            // will swallow it and wrap with a Throw()).
             stats.incr("db-async-cached-connection-release", 1)
             database.close(connection)
             tlConnection.remove()

--- a/querulous-core/src/main/scala/com/twitter/querulous/async/BlockingDatabaseWrapper.scala
+++ b/querulous-core/src/main/scala/com/twitter/querulous/async/BlockingDatabaseWrapper.scala
@@ -74,6 +74,7 @@ extends AsyncDatabase {
             // terminated with an unhandled exception. If neither is the case (e.g. this was a benign
             // exception like a SQL constraint violation), it still doesn't hurt much to return/re-borrow
             // the connection from the underlying database, given that this should be rare.
+            // TODO: Handle possible connection leakage if this thread is destroyed in some other way.
             database.close(connection)
             tlConnection.remove()
             throw e

--- a/querulous-core/src/test/scala/com/twitter/querulous/unit/StandardAsyncQueryEvaluatorSpec.scala
+++ b/querulous-core/src/test/scala/com/twitter/querulous/unit/StandardAsyncQueryEvaluatorSpec.scala
@@ -35,7 +35,6 @@ class StandardAsyncQueryEvaluatorSpec extends Specification with JMocker with Cl
         one(database).open()                                               willReturn connection
         one(queryFactory).apply(connection, QueryClass.Select, "SELECT 1") willReturn query
         one(query).select(fromRow)                                         willReturn Seq(1)
-        one(database).close(connection)
       }
 
       newEvaluator().select("SELECT 1")(fromRow).get()
@@ -48,7 +47,6 @@ class StandardAsyncQueryEvaluatorSpec extends Specification with JMocker with Cl
         one(database).open()                                               willReturn connection
         one(queryFactory).apply(connection, QueryClass.Select, "SELECT 1") willReturn query
         one(query).select(fromRow)                                         willReturn Seq(1)
-        one(database).close(connection)
       }
 
       newEvaluator().selectOne("SELECT 1")(fromRow).get()
@@ -61,7 +59,6 @@ class StandardAsyncQueryEvaluatorSpec extends Specification with JMocker with Cl
         one(database).open()                                               willReturn connection
         one(queryFactory).apply(connection, QueryClass.Select, "SELECT 1") willReturn query
         one(query).select(any[ResultSet => Int])                           willReturn Seq(1)
-        one(database).close(connection)
       }
 
       newEvaluator().count("SELECT 1").get()
@@ -76,7 +73,6 @@ class StandardAsyncQueryEvaluatorSpec extends Specification with JMocker with Cl
         one(database).open()                                         willReturn connection
         one(queryFactory).apply(connection, QueryClass.Execute, sql) willReturn query
         one(query).execute()                                         willReturn 1
-        one(database).close(connection)
       }
 
       newEvaluator().execute("INSERT INTO foo (id) VALUES (1)").get()
@@ -92,7 +88,6 @@ class StandardAsyncQueryEvaluatorSpec extends Specification with JMocker with Cl
         one(queryFactory).apply(connection, QueryClass.Execute, sql) willReturn query
         one(query).addParams(1)
         one(query).execute()                                         willReturn 1
-        one(database).close(connection)
       }
 
       newEvaluator().executeBatch("INSERT INTO foo (id) VALUES (?)")(_(1)).get()
@@ -110,7 +105,6 @@ class StandardAsyncQueryEvaluatorSpec extends Specification with JMocker with Cl
         one(query).execute()                                         willReturn 1
         one(connection).commit()
         one(connection).setAutoCommit(true)
-        one(database).close(connection)
       }
 
       newEvaluator().transaction(_.execute("INSERT INTO foo (id) VALUES (1)")).get()


### PR DESCRIPTION
The current model of using acquiring/releasing connections per query does not really make sense when there is a thread-per-connection in the async querulous work pool. This leads to avoidable lock contention on the pool and hence expensive context switches. 

In a Twitter flockdb deployment, this fix resulted in 20-25% lower CPU usage due to the reduced context switches. 
